### PR TITLE
Fix torchcodec import error

### DIFF
--- a/ailab_edgeTTS.py
+++ b/ailab_edgeTTS.py
@@ -8,6 +8,7 @@ import edge_tts
 import asyncio
 import re
 import torch
+import torchcodec
 import torchaudio
 import json
 
@@ -173,3 +174,4 @@ NODE_CLASS_MAPPINGS = {
 NODE_DISPLAY_NAME_MAPPINGS = {
     "EdgeTTS": "Edge TTS 🔊"
 } 
+

--- a/ailab_whisperSTT.py
+++ b/ailab_whisperSTT.py
@@ -1,5 +1,6 @@
 import os
 import torch
+import torchcodec
 import torchaudio
 import whisper
 import json
@@ -86,4 +87,5 @@ NODE_CLASS_MAPPINGS = {
 
 NODE_DISPLAY_NAME_MAPPINGS = {
     "WhisperSTT": "Whisper STT 👂"
+
 } 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
 edge-tts>=7.0.0
 torchaudio
-torchcodec==0.9
+torchcodec>=0.9
 openai-whisper>=20231117
 numpy
 #mutagen>=1.47.0  # For audio metadata handling
 torch
 googletrans-py>=3.0.0
 deep-translator>=1.11.4
+


### PR DESCRIPTION
This PR fixes an issue with torchcodec imports on some systems when using the WhisperSTT node.

`TorchCodec is required for save_with_torchcodec. Please install torchcodec to use this function.`

By explicitly importing torchcodec before torchaudio.save() is called, it guarantees that the correct version is used.

Also, this PR bumps torchcodec support to 0.9+